### PR TITLE
Issue 010

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NTP client for the Nintendo DS. Download [here](https://github.com/IvanVeloz/nds
 * Press A to set the time.
 * Press start to go exit the app, A to sync again, or B to go back to the start.
 
-Tip: you can get diagnostics information by holding down the L or R button before starting the app. Some information dismisses itself after 2 seconds, other information stays until you press a button.
+>Tip: you can get diagnostics information by holding down the L or R button before starting the app, or before starting some actions. Some information dismisses itself after 2 seconds, other information stays until you press a button.
 
 ### Background information
 Uses the coreNTP library made by Amazon for the FreeRTOS project. The library has been ported and targets one second precision (as that is the resolution for the NDS's real time clock). The project targets BlocksDS and real hardware. You can build it by installing the BlocksDS SDK and typing `make`.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # ndsntp
-NTP client for the Nintendo DS.
+NTP client for the Nintendo DS. Download [here](https://github.com/IvanVeloz/ndsntp/releases).
 
-Uses the coreNTP library made by Amazon for the FreeRTOS project. The library has been ported and targets one second precision (as that is the resolution for the NDS's real time clock).
+## Usage
+* Start the app
+* Use the arrow keys to configure your local timezone.
+  - The minutes go up in steps of 15, but if you keep pressing up, they go back to zero and increment in steps of 1.
+* Press A to set the time.
+* Press start to go exit the app, A to sync again, or B to go back to the start.
 
-The project targets BlocksDS and real hardware. You can build it by installing the BlocksDS SDK and typing `make`. Releases will be available in the near future.
+Tip: you can get diagnostics information by holding down the L or R button before starting the app. Some of it dismisses after 2 seconds, others need you to press any button.
 
-As of this version, the project can get an UNIX timestamp with UTC time from the server. Next steps are (in no particular order):
-* Writing to the hardware RTC (real time clock) rather than just printing.
+## Background information
+Uses the coreNTP library made by Amazon for the FreeRTOS project. The library has been ported and targets one second precision (as that is the resolution for the NDS's real time clock). The project targets BlocksDS and real hardware. You can build it by installing the BlocksDS SDK and typing `make`.
+
+## Project status
+As of this version, the project can get the time from an NTP server, apply your timezone settings, and store it in the NDS real time clock. You provide your timezone (for example UTC-04) with an user interface.
+
+Next steps are (in no particular order):
 * Reading a configuration file with the desired UTC offset
-    - Reading a configuration file with the desired TZ timezone, and having the offset calculated from that.
+* Using timezones from the Tz database (e.g. America/New_York or Asia/Shanghai) instead of UTC offsets (e.g. UTC+04:00 or UTC+8:00).
 * Implementing a mitigation for time-bombed R4 clones. Some R4 clone flashcarts stop working after the year 2024. What some people do is set the clock behind the real time, for example, setting the clock to the year 2014 instead of 2024. We can support this workaround by storing an offset instead of manipulating the real time clock.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ NTP client for the Nintendo DS. Download [here](https://github.com/IvanVeloz/nds
 * Press A to set the time.
 * Press start to go exit the app, A to sync again, or B to go back to the start.
 
-Tip: you can get diagnostics information by holding down the L or R button before starting the app. Some of it dismisses after 2 seconds, others need you to press any button.
+Tip: you can get diagnostics information by holding down the L or R button before starting the app. Some information dismisses itself after 2 seconds, other information stays until you press a button.
 
-## Background information
+### Background information
 Uses the coreNTP library made by Amazon for the FreeRTOS project. The library has been ported and targets one second precision (as that is the resolution for the NDS's real time clock). The project targets BlocksDS and real hardware. You can build it by installing the BlocksDS SDK and typing `make`.
 
-## Project status
+### Project status
 As of this version, the project can get the time from an NTP server, apply your timezone settings, and store it in the NDS real time clock. You provide your timezone (for example UTC-04) with an user interface.
 
 Next steps are (in no particular order):

--- a/arm9/source/core_sntp_callbacks.c
+++ b/arm9/source/core_sntp_callbacks.c
@@ -99,7 +99,7 @@ void sntpSetTime(   const SntpServerInfo_t * pTimeServer,
     };
 
     struct tm ts;
-    ts = *localtime(&t.tv_sec);
+    ts = RTC_IS_GMT? *gmtime(&t.tv_sec) : *localtime(&t.tv_sec);
 
     rtcTimeAndDate rtctime = {
         .year = ts.tm_year-100,        // -100 works until 2099. % works forever

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -37,7 +37,7 @@
  * So we provide the TZ variable ourselves for `localtime()` to do all timezone
  * conversions.
  */
-static char ndsntp_env_tz[256] = "TZ=NZST-12:00:00NZDT-13:00:00,M10.1.0,M3.3.0";
+static char ndsntp_env_tz[256] = "";
 static char *ndsntp_env[] = {
 	ndsntp_env_tz,
 	NULL

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -49,6 +49,7 @@ int main(void) {
 	
 	IF_DIAGNOSTICS {
 		printIpInfo();
+		sleeprtc(2);
 	}
 
 	struct hostent * ntphost = gethostbyname(ntpurl);

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -107,6 +107,7 @@ int main(void) {
 void spinloop(void) {
 	while(1) {
 		swiWaitForVBlank();
+		scanKeys();
 		int keys = keysDown();
 		if(keys) break;	
 	}

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -89,15 +89,6 @@ int main(void) {
 		else sleeprtc(2);
 	}
 
-	scanKeys();
-	IF_DIAGNOSTICS {
-		printEnviron();
-		tzset();
-		printf("%s\n%s\n",tzname[0],tzname[1]);
-		spinloop();
-		printf("\x1b[2J"); // Clear console
-	}
-
 	enum Menu menu = MENU_TZ;
 	while( 1 )
     {

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -29,7 +29,7 @@
 #define IF_DIAGNOSTICS					\
 	swiWaitForVBlank();					\
 	scanKeys();							\
-	if(keysDown() & (KEY_L|KEY_R))
+	if(keysCurrent() & (KEY_L|KEY_R))
 
 const char * ntpurl = "us.pool.ntp.org";
 

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -14,6 +14,7 @@
 #include <netinet/in.h>
 #include <netdb.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <assert.h>
 #include <time.h>
 #include <core_sntp_client.h>
@@ -27,16 +28,19 @@
 #define NTP_RECEIVE_WAIT_TIME_MS		1000
 
 #define IF_DIAGNOSTICS					\
-	swiWaitForVBlank();					\
-	scanKeys();							\
 	if(keysCurrent() & (KEY_L|KEY_R))
 
 const char * ntpurl = "us.pool.ntp.org";
+
+enum Menu { MENU_TZ, MENU_SYNCING, MENU_SYNCED, MENU_EXIT };
 
 void spinloop(void);
 unsigned int sleeprtc(unsigned int seconds);
 void printIpInfo(void);
 int printNsLookup(void);
+int syncTime(int retries);
+enum Menu displayTZMenu(void);
+enum Menu displaySyncedMenu(void);
 
 int main(void) {
 
@@ -48,71 +52,49 @@ int main(void) {
 		goto end;
 	}
 	
+	scanKeys();
 	IF_DIAGNOSTICS {
 		printIpInfo();
 		sleeprtc(2);
 	}
 
+	scanKeys();
 	IF_DIAGNOSTICS {
 		if(printNsLookup()) spinloop();
 		else sleeprtc(2);
 	}
 	
-	uint8_t netBuffer[SNTP_PACKET_BASE_SIZE];
-	NetworkContext_t netContext = {
-		.udpSocket = socket(AF_INET, SOCK_DGRAM, 0)
-	};
-	SntpServerInfo_t server = {
-		.port = SNTP_DEFAULT_SERVER_PORT,
-		.pServerName = ntpurl,
-		.serverNameLen = strlen(ntpurl)
-	};
-    UdpTransportInterface_t udpTransportIntf = {
-		.pUserContext = &netContext,
-		.sendTo = sntpUdpSend,
-		.recvFrom = sntpUdpRecv
-	};
-	SntpContext_t sntpContext;
-	
-    SntpStatus_t status = Sntp_Init( &sntpContext,
-                                     &server,
-                                     sizeof(server) / sizeof(SntpServerInfo_t),
-                                     NTP_TIMEOUT,
-                                     netBuffer,
-                                     SNTP_PACKET_BASE_SIZE,
-                                     sntpResolveDns,
-                                     sntpGetTime,
-                                     sntpSetTime,
-                                     &udpTransportIntf,
-                                     NULL );
-	
-	assert(status == SntpSuccess);
-
+	enum Menu menu = MENU_TZ;
 	while( 1 )
     {
-        status = Sntp_SendTimeRequest( &sntpContext,
-                                       rand() % UINT32_MAX,
-                                       NTP_SEND_WAIT_TIME_MS );
-		printf("Sntp_SendTimeRequest = %u\n", (unsigned int)status);
-		if ( status != SntpSuccess ) continue;
- 
-        do
-        {
-            status = Sntp_ReceiveTimeResponse( &sntpContext, NTP_RECEIVE_WAIT_TIME_MS );
-        } while( status == SntpNoResponseReceived );
- 		printf("Sntp_ReceiveTimeResponse = %u\n", (unsigned int)status);
-        if ( status != SntpSuccess ) continue;
-
-		printf("\n\n\nRTC is %llu\n", time(NULL));
-		printf("Press A to sync again.\n"
-			   "Press Start to power off.\n");
-		while(1) {
-			swiWaitForVBlank();
-			scanKeys();
-			int keys = keysDown();
-			if(keys & KEY_START) goto end;
-			if(keys & KEY_A) break;
+		switch(menu) {
+			case MENU_TZ:
+				menu = displayTZMenu();
+				break;
+			case MENU_SYNCING:
+				swiWaitForVBlank();
+				scanKeys();
+				printf("\x1b[2J"); // Clear console
+				printf("\n\n");
+				if(syncTime(5)) {
+					printf("Couldn't connect to time server(s)!\n");
+				}
+				IF_DIAGNOSTICS {
+					sleeprtc(2);
+				}
+				menu = MENU_SYNCED;
+				break;
+			case MENU_SYNCED:
+				menu = displaySyncedMenu();
+				break;
+			case MENU_EXIT:
+				goto end;
+			default:
+				menu = MENU_TZ;
 		}
+
+
+
 		printf("\n\n");
     }
 	end:
@@ -142,6 +124,8 @@ unsigned int sleeprtc(unsigned int seconds) {
 	return 0;
 }
 
+/* Print IP address information for diagnostics.
+ */
 void printIpInfo(void) {
 	struct in_addr ip, gateway, mask, dns1, dns2;
 	ip = Wifi_GetIPInfo(&gateway, &mask, &dns1, &dns2);
@@ -153,6 +137,8 @@ void printIpInfo(void) {
 	printf("ntp url: %s\n",ntpurl);
 }
 
+/* Lookup the NTP hostname and print the entry(ies) given by the DNS server.
+ */
 int printNsLookup(void) {
 	struct hostent * ntphost = gethostbyname(ntpurl);
 	if(ntphost == NULL) {
@@ -174,4 +160,156 @@ int printNsLookup(void) {
 	return 0;
 }
 
+/* Connect to an NTP server and set the time (assumes locale is set; if not set
+ * it defaults to UTC).
+ */
+int syncTime(int retries)
+{
+	uint8_t netBuffer[SNTP_PACKET_BASE_SIZE];
+	NetworkContext_t netContext = {
+		.udpSocket = socket(AF_INET, SOCK_DGRAM, 0)
+	};
+	SntpServerInfo_t server = {
+		.port = SNTP_DEFAULT_SERVER_PORT,
+		.pServerName = ntpurl,
+		.serverNameLen = strlen(ntpurl)
+	};
+    UdpTransportInterface_t udpTransportIntf = {
+		.pUserContext = &netContext,
+		.sendTo = sntpUdpSend,
+		.recvFrom = sntpUdpRecv
+	};
+	SntpContext_t sntpContext;
+	
+    SntpStatus_t status = Sntp_Init( &sntpContext,
+                                     &server,
+                                     sizeof(server) / sizeof(SntpServerInfo_t),
+                                     NTP_TIMEOUT,
+                                     netBuffer,
+                                     SNTP_PACKET_BASE_SIZE,
+                                     sntpResolveDns,
+                                     sntpGetTime,
+                                     sntpSetTime,
+                                     &udpTransportIntf,
+                                     NULL );
+	if(status != SntpSuccess) {
+		LogError(("Failed to initialize SNTP.\n"));
+		return -1;
+	}
 
+	int i,j;
+	for(i=0, j=0; i<retries; i++) {
+		status = Sntp_SendTimeRequest( &sntpContext,
+										rand() % UINT32_MAX,
+										NTP_SEND_WAIT_TIME_MS );
+		if ( status != SntpSuccess ) continue;
+		do {
+            status = Sntp_ReceiveTimeResponse( &sntpContext, NTP_RECEIVE_WAIT_TIME_MS );
+        } while( status == SntpNoResponseReceived );
+		if ( status != SntpSuccess ) continue;
+		break;
+	}
+
+	if(i>=retries || j>=retries) {
+		LogError(("Failed to request SNTP time.\n"));
+		return -1;
+	}
+	else 
+		return 0;
+}
+
+/* Display the timezone setting dialog. 
+ * @returns an `enum Menu` with the next menu that should be displayed.
+ */
+enum Menu displayTZMenu(void)
+{
+	enum Selection {s_hour, s_minute};
+	struct Tz {int8_t hour; uint8_t minute;};
+
+	static enum Selection sel = s_hour;
+	static struct Tz tz = {.hour=0, .minute=0};
+
+	swiWaitForVBlank();
+	printf("\x1b[2J"); // Clear console
+	const int coord_x[2] = {
+		5, 8
+	};
+	printf("\n\nTimezone:\n\n");
+	printf("\x1b[%dC^\n", coord_x[sel]);
+	printf("UTC%+03i:%02u\n", tz.hour, tz.minute%60);
+    printf("\x1b[%dCv\n", coord_x[sel]);
+
+	printf(	"\n\n\n\n\n\n\n\n\n\n\n\n"
+			"Press A to sync time.\n"
+			"Press Start to exit.");
+
+	scanKeys();
+	uint16_t keys = keysDownRepeat();
+
+	if(keys & KEY_A) {
+		tz.minute = tz.minute % 60;
+		// TODO: change the system locale right here
+		return MENU_SYNCING;
+	}
+	else if(keys & KEY_LEFT) {
+		if(sel>s_hour) sel--;
+	}
+	else if(keys & KEY_RIGHT) {
+		if(sel<s_minute) sel++;
+	}
+	else if(keys & KEY_UP) {
+		switch(sel) {
+			case s_hour:
+				if(tz.hour >= 16) tz.hour = 16;
+				else tz.hour += 1;
+				break;
+			case s_minute:
+				if(tz.minute >= 120) tz.minute = 120;
+				else if(tz.minute >= 60) tz.minute += 1;
+				else tz.minute += 15;
+				break;
+		}
+	}
+	else if(keys & KEY_DOWN) {
+		switch(sel) {
+			case s_hour:
+				if(tz.hour <= -16) tz.hour = 16;
+				else tz.hour -= 1;
+				break;
+			case s_minute:
+				if(tz.minute <= 0) tz.minute = 0;
+				else if(tz.minute > 60) tz.minute -= 1;
+				else tz.minute -= 15;
+				break;
+		}
+	}
+	else if(keys & KEY_START) {
+		return MENU_EXIT;
+	}
+
+	return MENU_TZ;
+
+}
+
+enum Menu displaySyncedMenu(void)
+{
+	char str[100];
+	time_t t = time(NULL);
+	struct tm *tmp = localtime(&t);
+	swiWaitForVBlank();
+	printf("\x1b[2J"); // Clear console
+	printf("\n\nCurrent time:\n\n\n");
+	if (strftime(str, sizeof(str), "%Y-%m-%dT%H:%M:%S%z", tmp) == 0)
+		snprintf(str, sizeof(str), "Failed to get time");
+	printf("%s\n", str);
+	printf("\n\n\n\n\n\n\n\n\n\n\n\n");
+	printf("Press A to sync again.\n"
+		"Press B to go back.\n"
+		"Press Start to exit.\n");
+	scanKeys();
+	int keys = keysDown();
+	if(keys & KEY_START) return MENU_EXIT;
+	if(keys & KEY_A) return MENU_SYNCING;
+	if(keys & KEY_B) return MENU_TZ;
+	return MENU_SYNCED;
+}

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -46,6 +46,7 @@ int main(void) {
 
 	consoleDemoInit();
 
+	scanKeys();
 	if(!Wifi_InitDefault(WFC_CONNECT)) {
 		printf("WFC connection failed. Check your wireless settings.\n");
 		spinloop();

--- a/include/core_sntp_callbacks.h
+++ b/include/core_sntp_callbacks.h
@@ -16,6 +16,10 @@
 #define FIFO_NDSNTP FIFO_USER_01
 #endif
 
+#ifndef RTC_IS_GMT
+#define RTC_IS_GMT	false
+#endif
+
 struct NetworkContext
 {
     int udpSocket;


### PR DESCRIPTION
Implement setting the timezone via user interface. The interface is text only, similar to the [rtc_set_get](https://github.com/blocksds/sdk/tree/master/examples/time/rtc_set_get) example on BlocksDS. The interface has two spinboxes for setting the hour (1hr increments) and minute offset (15 minute increments for Nepal, etc.).

In the future, the goal is for time zones to be in the TZ style. That is, something like “America/New_York”. But that requires having a copy of the TZ database, among other complications.

To verify:
* Documentation is updated (readme / instructions)
* Program passes manual testing in hardware