### PR TITLE
Fix compilation with blocksds 14+ and enable dsi wifi support

### DIFF
--- a/arm9/source/core_sntp_callbacks.c
+++ b/arm9/source/core_sntp_callbacks.c
@@ -30,7 +30,7 @@ bool sntpResolveDns(const SntpServerInfo_t * pServerAddr,
 
     if(ntphost == NULL)                 return false;
 	if(ntphost->h_addrtype != AF_INET)  return false;
-	if(ntphost->h_length != 4)          return false;
+	if(ntphost->h_length < 4)           return false;
 
     struct in_addr addr = *(struct in_addr *)ntphost->h_addr_list[0];
     *pIpV4Addr = htonl((uint32_t)addr.s_addr);
@@ -193,7 +193,7 @@ int32_t sntpUdpRecv(NetworkContext_t * pNetworkContext,
         goto cleanup;
     }
     else if (r > 0) {
-        int addrlen = sizeof(addri);
+        socklen_t addrlen = sizeof(addri);
         r = recvfrom(   pNetworkContext->udpSocket, pBuffer,bytesToRecv, 0,
                         (struct sockaddr *)(&addri), &addrlen);
     }

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -72,7 +72,7 @@ int main(void) {
 	consoleDemoInit();
 
 	printf("Connecting to WLAN\n");
-	if(!Wifi_InitDefault(WFC_CONNECT)) {
+	if(!Wifi_InitDefault(WFC_CONNECT | WIFI_ATTEMPT_DSI_MODE)) {
 		printf("WFC connection failed. Check your wireless settings.\n");
 		spinloop();
 		goto end;

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -175,7 +175,7 @@ int printNsLookup(void) {
 
 	/* Assert that we're dealing with IPv4 addresses, 32 bit lengths. */
 	assert(ntphost->h_addrtype == AF_INET);
-	assert(ntphost->h_length == 4);
+	assert(ntphost->h_length >= 4);
 	printf("h_name : %s\n",ntphost->h_name);
 	for(size_t i=0; ntphost->h_aliases[i] != NULL; i++) {
 		printf("h_alias: %s\n",ntphost->h_aliases[i]);

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -29,7 +29,7 @@
 
 /* Function macros */
 #define IF_DIAGNOSTICS					\
-	if(keysCurrent() & (KEY_L|KEY_R))
+	if(keysHeld() & (KEY_L|KEY_R))
 
 /* Environment variables *
  * These are used by some POSIX functions and are normally provided by the
@@ -42,7 +42,8 @@ static char *ndsntp_env[] = {
 	ndsntp_env_tz,
 	NULL
 };
-extern char **environ = &ndsntp_env[0];	// Provide our own environment variables
+extern char **environ;
+char **environ = &ndsntp_env[0];	// Provide our own environment variables
 extern char *tzname[2];
 
 /* Global types */
@@ -97,7 +98,7 @@ int main(void) {
 				menu = displayTZMenu();
 				break;
 			case MENU_SYNCING:
-				swiWaitForVBlank();
+				cothread_yield_irq(IRQ_VBLANK);
 				scanKeys();
 				printf("\x1b[2J"); // Clear console
 				printf("\n\n");
@@ -130,7 +131,7 @@ int main(void) {
  */
 void spinloop(void) {
 	while(1) {
-		swiWaitForVBlank();
+		cothread_yield_irq(IRQ_VBLANK);
 		scanKeys();
 		int keys = keysDown();
 		if(keys) break;	
@@ -145,7 +146,7 @@ void spinloop(void) {
  */
 unsigned int sleeprtc(unsigned int seconds) {
 	for(time_t t = time(NULL), l=t+seconds+1; t<l; t = time(NULL)) {
-		swiWaitForVBlank();	// I assume this is more energy efficient
+		cothread_yield_irq(IRQ_VBLANK);	// I assume this is more energy efficient
 	}
 	return 0;
 }
@@ -264,7 +265,7 @@ enum Menu displayTZMenu(void)
 	static enum Selection sel = s_hour;
 	static struct Tz tz = {.hour=0, .minute=0};
 
-	swiWaitForVBlank();
+	cothread_yield_irq(IRQ_VBLANK);
 	printf("\x1b[2J"); // Clear console
 	const int coord_x[2] = {
 		5, 8
@@ -346,7 +347,7 @@ enum Menu displaySyncedMenu(void)
 	char str[100];
 	time_t t = time(NULL);
 	struct tm *tmp = RTC_IS_GMT? localtime(&t) : gmtime(&t);
-	swiWaitForVBlank();
+	cothread_yield_irq(IRQ_VBLANK);
 	printf("\x1b[2J"); // Clear console
 	printf("\n\nCurrent time:\n\n\n");
 	if (strftime(str, sizeof(str), "%Y-%m-%dT%H:%M:%S%z", tmp) == 0)


### PR DESCRIPTION
Other than fixing new warnings/errors raised by a newer gcc, the stack change from sgIP to lwIP changed some behaviour, specifically now gethostbyname can return more than 1 address (rightfully so), making the previous check in the dns resolve function to fail.
Also enabled the dsi wifi flag now that it is supported by blocksds, making this app properly usable on dsi.