### PR TITLE
Fix compilation with latest blocksds and logic error

### DIFF
--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -44,7 +44,6 @@ static char *ndsntp_env[] = {
 };
 extern char **environ;
 char **environ = &ndsntp_env[0];	// Provide our own environment variables
-extern char *tzname[2];
 
 /* Global types */
 struct Tz {
@@ -72,48 +71,52 @@ int main(void) {
 	consoleDemoInit();
 
 	printf("Connecting to WLAN\n");
+	
 	if(!Wifi_InitDefault(INIT_ONLY | WIFI_ATTEMPT_DSI_MODE)) {
-		Wifi_AutoConnect();
-		for(	
-			enum WIFI_ASSOCSTATUS s=Wifi_AssocStatus(), sl=s; 
-			sl!=ASSOCSTATUS_ASSOCIATED; 
-			sl=s, s = Wifi_AssocStatus()
-		){	// this loop is mostly a flex
-			switch(s) {
-				case ASSOCSTATUS_SEARCHING:
-					if(sl != s)
-						printf("Searching for AP...\n");
-					break;
-				case ASSOCSTATUS_ASSOCIATING:
-					if(sl != s)
-						printf("Associating...\n");
-					break;
-				case ASSOCSTATUS_AUTHENTICATING:
-					if(sl != s)
-						printf("Authenticating...\n");
-					break;
-				case ASSOCSTATUS_ACQUIRINGDHCP:
-					if(sl != s) 
-						printf("Acquiring IP address...\n");
-					break;
-				case ASSOCSTATUS_ASSOCIATED:
-					printf("Associated!\n");
-					break;
-				case ASSOCSTATUS_CANNOTCONNECT:
-					printf("Cannot connect; error.\n");
-					[[fallthrough]];
-				case ASSOCSTATUS_DISCONNECTED:
-					[[fallthrough]];
-				default:
-					printf("WFC connection failed. Check your wireless settings.\n");
-					spinloop();
-					goto end;
-			}
-			cothread_yield_irq(IRQ_VBLANK);
-		}
-		printf("Connected to the AP!\n");
-
+		printf("WIFI hardware initialization failed.\n");
+		spinloop();
+		goto end;
 	}
+	
+	Wifi_AutoConnect();
+	for(
+		enum WIFI_ASSOCSTATUS s=Wifi_AssocStatus(), sl=s; 
+		sl!=ASSOCSTATUS_ASSOCIATED; 
+		sl=s, s = Wifi_AssocStatus()
+	){	// this loop is mostly a flex
+		switch(s) {
+			case ASSOCSTATUS_SEARCHING:
+				if(sl != s)
+					printf("Searching for AP...\n");
+				break;
+			case ASSOCSTATUS_ASSOCIATING:
+				if(sl != s)
+					printf("Associating...\n");
+				break;
+			case ASSOCSTATUS_AUTHENTICATING:
+				if(sl != s)
+					printf("Authenticating...\n");
+				break;
+			case ASSOCSTATUS_ACQUIRINGDHCP:
+				if(sl != s) 
+					printf("Acquiring IP address...\n");
+				break;
+			case ASSOCSTATUS_ASSOCIATED:
+				printf("Associated!\n");
+				break;
+			case ASSOCSTATUS_CANNOTCONNECT:
+				printf("Cannot connect; error.\n");
+				[[fallthrough]];
+			case ASSOCSTATUS_DISCONNECTED:
+				[[fallthrough]];
+			default:
+				printf("WFC connection failed. Check your wireless settings.\n");
+				spinloop();
+				goto end;
+		}
+		cothread_yield_irq(IRQ_VBLANK);
+	}
+	printf("Connected to the AP!\n");
 
 	scanKeys();
 	IF_DIAGNOSTICS {


### PR DESCRIPTION
The symbol `tzname` is included by `time.h`, and in the latest headers it got declared with a different typing than the one it was forward declared here, remove the extra declaration.
The other fix is for the wifi init code, in the [latest commit on master](https://github.com/IvanVeloz/ndsntp/commit/540cd24e4958f80e17598e73a09535cfa17b44f6), the call to `Wifi_InitDefault` was changed to pass `INIT_ONLY` instead of `WFC_CONNECT`, with this change, `Wifi_InitDefault' can only return `false` if hw initialization fails, and when it returns true, no connection has been performed yet, so the connection loop that was added in the negative branch needs to actually always be executed.